### PR TITLE
Release v1.0.1 — Crash fix + Rating prompt + Android 15 APIs

### DIFF
--- a/app.json
+++ b/app.json
@@ -29,6 +29,15 @@
       "requireFullScreen": false,
       "userInterfaceStyle": "automatic"
     },
+    "androidStatusBar": {
+      "barStyle": "light-content",
+      "backgroundColor": "#00000000",
+      "translucent": true
+    },
+    "androidNavigationBar": {
+      "barStyle": "dark-content",
+      "backgroundColor": "#FFFFFF"
+    },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
@@ -36,7 +45,8 @@
       },
       "package": "xyz.jsmglobal.ace",
       "versionCode": 29,
-      "permissions": []
+      "permissions": [],
+      "edgeToEdgeEnabled": true
     },
     "web": {
       "favicon": "./assets/favicon.png",
@@ -45,7 +55,15 @@
     "plugins": [
       "expo-router",
       "expo-font",
-      "expo-asset"
+      "expo-asset",
+      [
+        "expo-navigation-bar",
+        {
+          "position": "absolute",
+          "visibility": "visible",
+          "behavior": "overlay-swipe"
+        }
+      ]
     ],
     "experiments": {
       "typedRoutes": true

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,10 +1,18 @@
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+import * as NavigationBar from 'expo-navigation-bar';
 import * as SplashScreen from 'expo-splash-screen';
+import { Platform } from 'react-native';
 import { Colors } from '../constants/theme';
 
 // Hide splash immediately — no need to keep it around
 SplashScreen.hideAsync();
+
+// Set navigation bar colors using the modern API (avoids deprecated Android 15 APIs)
+if (Platform.OS === 'android') {
+  NavigationBar.setBackgroundColorAsync('#FFFFFF');
+  NavigationBar.setButtonStyleAsync('dark');
+}
 
 export default function RootLayout() {
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "expo-haptics": "~15.0.8",
         "expo-linear-gradient": "~15.0.8",
         "expo-linking": "~8.0.11",
+        "expo-navigation-bar": "~5.0.10",
         "expo-router": "~6.0.23",
         "expo-splash-screen": "~31.0.13",
         "expo-status-bar": "~3.0.9",
@@ -4690,6 +4691,22 @@
         "invariant": "^2.2.4"
       },
       "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-navigation-bar": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/expo-navigation-bar/-/expo-navigation-bar-5.0.10.tgz",
+      "integrity": "sha512-r9rdLw8mY6GPMQmVVOY/r1NBBw74DZefXHF60HxhRsdNI2kjc1wLdfWfR2rk4JVdOvdMDujnGrc9HQmqM3n8Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-native/normalize-colors": "0.81.5",
+        "debug": "^4.3.2",
+        "react-native-is-edge-to-edge": "^1.2.1"
+      },
+      "peerDependencies": {
+        "expo": "*",
         "react": "*",
         "react-native": "*"
       }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "expo-haptics": "~15.0.8",
     "expo-linear-gradient": "~15.0.8",
     "expo-linking": "~8.0.11",
+    "expo-navigation-bar": "~5.0.10",
     "expo-router": "~6.0.23",
     "expo-splash-screen": "~31.0.13",
     "expo-status-bar": "~3.0.9",


### PR DESCRIPTION
## Changes

### Bug Fixes
- **Critical**: JavascriptException crash fix (12 users / 272 events)
- Android 15 deprecated edge-to-edge APIs fixed
- Removed broken deploy workflows

### Features
- Native in-app rating prompt (expo-store-review)
- Improved rating message and trigger (2 quizzes / 5 days)

### Config
- Added expo-navigation-bar plugin
- Enabled edgeToEdgeEnabled for modern Android
- Notify workflow triggers on dev branch
- GitHub Issues re-enabled for build prompts